### PR TITLE
add handling for sourceFolder (relative paths) and compound folders (…

### DIFF
--- a/commands/oss.js
+++ b/commands/oss.js
@@ -75,7 +75,7 @@ const files = require('../lib/files.js');
         const rawApiUrl = `https://api.github.com/repos/${context.flags.repository}/git/trees/${branch}?recursive=1`;
 
 
-        // check to ensure sfdx-oss-manifest.json exists   
+        // check to ensure sfdx-oss-manifest.json exists
         urlExists(rawUrlManifest, (err2, manifestExists) => {
           if (!manifestExists) {
             console.log('sfdx-oss-manifest.json not found in repository'); // eslint-disable-line no-console
@@ -110,20 +110,22 @@ const files = require('../lib/files.js');
                 }
 
               });
-              
+
 
               // grab the files
               const manifestFiles = manifestJson.files;
 
-              files.writeFiles(manifestFiles, targetPath, rawUrlManifestFolder, (outputFiles) => {
+              if (manifestFiles.length>0){
+                files.writeFiles(manifestFiles, targetPath, rawUrlManifestFolder, (outputFiles) => {
 
-                console.log('Writing files ...'); // eslint-disable-line no-console
+                  console.log('Writing files ...'); // eslint-disable-line no-console
 
-                for (let i = 0, len = outputFiles.length; i < len; i++) {
-                  console.log(`  ${outputFiles[i]}`); // eslint-disable-line no-console
-                }
+                  for (let i = 0, len = outputFiles.length; i < len; i++) {
+                    console.log(`  ${outputFiles[i]}`); // eslint-disable-line no-console
+                  }
 
-              });
+                });
+              }
 
             } else {
               console.log('Only version 1.0.0 is currently supported'); // eslint-disable-line no-console

--- a/lib/files.js
+++ b/lib/files.js
@@ -17,7 +17,7 @@ module.exports = {
         body += chunk;
       });
 
-      manifestResponse.on('end', () => { 
+      manifestResponse.on('end', () => {
         result(body);
       });
 
@@ -68,37 +68,47 @@ module.exports = {
 
       async.each(jsonBody.tree, (fileName, callback2) => {
 
-        // console.log(fileName.path);
         let fileNamePath = fileName.path;
         const type = fileName.type;
 
+        //console.log(fileName.path);
+
         if (type === 'blob') {
+          if (fileNamePath.indexOf('/') >= 0) { //that means it has a / in it, so nothing from top level
+            //console.log(fileNamePath + "=================");
 
-          if (fileNamePath.indexOf('/') >= 0) {
+            const relativeToSource = fileNamePath.replace(sourceFolder + '/', '');
+            //console.log("relativeToSource (" + sourceFolder + "): " + relativeToSource);
 
-            // const fileNameSplit = fileNamePath.split('/');
-            // const fileNameFirstPart = fileNameSplit[0];
+            if (!sourceFolder || fileName.path.indexOf(sourceFolder)> -1){
 
-            // if (manifestFolders.indexOf(fileNameFirstPart) > -1) {
+              const fileNameSplit = relativeToSource.split('/');
+              //console.log("matches source folder!");
 
-              fileNamePath = fileNamePath.replace(sourceFolder, '');
+              for (let i=0; i<manifestFolders.length; i++){ //check against each folder
+                //console.log("checking folder" + manifestFolders[i]);
+                if (relativeToSource.indexOf(manifestFolders[i])==0){
 
-              const filePathAndName = path.join(targetPath, fileNamePath);
-              const filePath = path.dirname(filePathAndName);
+                  fileNamePath = fileNamePath.replace(sourceFolder, '');
 
-              console.log(fileNamePath);
+                  const filePathAndName = path.join(targetPath, fileNamePath);
+                  const filePath = path.dirname(filePathAndName);
 
-              fse.ensureDirSync(filePath);
+                  console.log("file from manifest folder " + manifestFolders[i] + " : " + fileNamePath);
 
-              const localFile = fs.createWriteStream(filePathAndName);
-              const fileUrl = `${rawUrlManifestFolder}/${fileNamePath}`;
-              
-              https.get(fileUrl, (fileResponse) => {
-                fileResponse.pipe(localFile);
-              });
-            // }
-          }
-        }
+                  fse.ensureDirSync(filePath);
+
+                  const localFile = fs.createWriteStream(filePathAndName);
+                  const fileUrl = `${rawUrlManifestFolder}/${fileNamePath}`;
+
+                  https.get(fileUrl, (fileResponse) => {
+                    fileResponse.pipe(localFile);
+                  });
+                } //else {console.log("doesn't match this folder");}
+              } //end of folder loop
+            } //else {console.log("disqualified for not matching source folder");}
+          } //else {console.log("disqualified for being top level");}
+        } //else {console.log("disqualified because not blob");}
 
         callback2();
       });


### PR DESCRIPTION
…aura/myComponent)

Try this against /mshanemc/LightningErrorHandler, for example.   That uses the sourceFolder option.  

The original version was getting things from /src/ folder that matched the folders.  The original split('/') didn't support folders like /aura/someComponent because of the slash.  Now it does.

