### PR TITLE
Change length of generated consumer secret to 32 characters

### DIFF
--- a/lib/forceUtils.js
+++ b/lib/forceUtils.js
@@ -7,7 +7,7 @@ module.exports = {
   getConsumerSecret: () => {
       let generatedConsumerSecret = '';
       const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-      for (let i=0; i < 9; i++ ) {
+      for (let i = 0; i < 32; i++) {
           generatedConsumerSecret += possible.charAt(Math.floor(Math.random() * possible.length));
       }
       return generatedConsumerSecret;


### PR DESCRIPTION
As of the the Spring '19 release Salesforce requires the consumer secret for connected apps to be at least 32 characters.

This commit changes the length of consumer secrets generated for connected apps from 9 characters to 32.