### PR TITLE
Fix plugin installation

### DIFF
--- a/lib/forceUtils.js
+++ b/lib/forceUtils.js
@@ -7,7 +7,7 @@ module.exports = {
   getConsumerSecret: () => {
       let generatedConsumerSecret = '';
       const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-      for (let i=0; i < 9; i++ ) {
+      for (let i=0; i < 32; i++ ) {
           generatedConsumerSecret += possible.charAt(Math.floor(Math.random() * possible.length));
       }
       return generatedConsumerSecret;

--- a/lib/forceUtils.js
+++ b/lib/forceUtils.js
@@ -7,7 +7,7 @@ module.exports = {
   getConsumerSecret: () => {
       let generatedConsumerSecret = '';
       const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-      for (let i=0; i < 32; i++ ) {
+      for (let i = 0; i < 32; i++) {
           generatedConsumerSecret += possible.charAt(Math.floor(Math.random() * possible.length));
       }
       return generatedConsumerSecret;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfdx-waw-plugin",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.5",
   "description": "A plugin for the Salesforce CLI built by Wade Wegner and containing a lot of helpful commands.",
   "main": "index.js",
+  "files": [
+    "*"
+  ],
   "author": "Wade Wegner @WadeWegner",
   "repository": "WadeWegner/sfdx-waw-plugin",
   "bugs": {


### PR DESCRIPTION
Fixes error message in [issue #18](https://github.com/wadewegner/sfdx-waw-plugin/issues/18)

But plugin still does not install properly with sfdx-cli 7.1.*, as running `sfdx plugins` does not return it in the list