### PR TITLE
update waw:workbench:open to default to the active connection's api version

### DIFF
--- a/src/commands/waw/workbench/open.ts
+++ b/src/commands/waw/workbench/open.ts
@@ -74,7 +74,8 @@ export default class ConnectedAppCreate extends SfdxCommand {
 
     const accessToken = conn.accessToken;
     const instanceUrl = conn.instanceUrl;
-    const serverUrl = `${instanceUrl}/services/Soap/u/46.0`;
+    const apiVersion = conn.version;
+    const serverUrl = `${instanceUrl}/services/Soap/u/${apiVersion}`;
 
     const workbenchUrlWithSid = url.resolve(targetWorkbenchUrl, `/login.php?serverUrl=${serverUrl}&sid=${accessToken}`);
 

--- a/src/commands/waw/workbench/open.ts
+++ b/src/commands/waw/workbench/open.ts
@@ -74,7 +74,7 @@ export default class ConnectedAppCreate extends SfdxCommand {
 
     const accessToken = conn.accessToken;
     const instanceUrl = conn.instanceUrl;
-    const serverUrl = `${instanceUrl}/services/Soap/u/41.0`;
+    const serverUrl = `${instanceUrl}/services/Soap/u/46.0`;
 
     const workbenchUrlWithSid = url.resolve(targetWorkbenchUrl, `/login.php?serverUrl=${serverUrl}&sid=${accessToken}`);
 


### PR DESCRIPTION
Make default API version for opening workbench the active connection's api version