### PR TITLE
For Windows Users

### DIFF
--- a/src/lib/sfdx.ts
+++ b/src/lib/sfdx.ts
@@ -1,6 +1,7 @@
 import { SfdxError } from '@salesforce/core';
 import { Dictionary, get } from '@salesforce/ts-types';
 import { spawn, SpawnOptions } from 'child_process';
+const os = require('os');
 
 export const runCommand = (fullCommand: string): Promise<Dictionary> => {
   const error = new Error(); // Get stack here to use for later
@@ -15,7 +16,8 @@ export const runCommand = (fullCommand: string): Promise<Dictionary> => {
 
   const spawnOpt: SpawnOptions = {
     // Always use json in stdout
-    env: Object.assign({ SFDX_JSON_TO_STDOUT: 'true' }, process.env)
+    env: Object.assign({ SFDX_JSON_TO_STDOUT: 'true' }, process.env),
+    shell: os.platform() === 'win32' //FOR WINDOWS USERS
   };
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
I used your project as a point of start and I was having problems with spawn when running on Windows. Then I used the same code on a Ubuntu VM and everything worked perfectly. So, after some search I discovered that windows users must pass  shell: true as an option to spawn. After adding it the error was gone and the code was running in both places.
Also, thank you for the code. It is helping me a lot to learn about sfdx plugins.